### PR TITLE
add ability to "vmcloak install" while host is running

### DIFF
--- a/vmcloak/main.py
+++ b/vmcloak/main.py
@@ -47,6 +47,9 @@ def initvm(image, name=None):
 
     if image.vm == "virtualbox":
         m = VirtualBox(name=name or image.name)
+        if m.list_runningvms():
+            return m, h
+
         m.create_vm()
         m.os_type(image.osversion)
         m.cpus(image.cpus)
@@ -277,7 +280,7 @@ def install(name, dependencies, vm_visible, debug):
 
     m, h = initvm(image)
 
-    if image.vm == "virtualbox":
+    if image.vm == "virtualbox" and not m.list_runningvms():
         m.start_vm(visible=vm_visible)
 
     wait_for_host(image.ipaddr, image.port)

--- a/vmcloak/vm.py
+++ b/vmcloak/vm.py
@@ -232,3 +232,12 @@ class VirtualBox(Machinery):
             vendorurl="http://cuckoosandbox.org/",
             description="Cuckoo Sandbox Virtual Machine created by VMCloak",
         )
+
+    def list_runningvms(self):
+        lines = self._call("list", "runningvms")
+        for line in lines.split("\n"):
+            if line.startswith('"{0}'.format(self.name)):
+                log.debug("VM {0} is already running".format(self.name))
+                return True
+
+        return False


### PR DESCRIPTION
it's like a workaround, but helps to proceed installing packages while agent connection breaks due to strange issues and causes vmcloak crash 
