### PR TITLE
Add pafish dependency

### DIFF
--- a/vmcloak/dependencies/pafish.py
+++ b/vmcloak/dependencies/pafish.py
@@ -1,0 +1,19 @@
+# Copyright (C) 2016 Markus Teufelberger.
+# This file is part of VMCloak - http://www.vmcloak.org/.
+# See the file 'docs/LICENSE.txt' for copying permission.
+
+from vmcloak.abstract import Dependency
+
+class Pafish(Dependency):
+    name = "pafish"
+    default = "058"
+    exes = [
+        {
+            "version": "058",
+            "url": "https://github.com/a0rtega/pafish/raw/master/pafish.exe",
+            "sha1": "124f46228d1e220d88ae5e9a24d6e713039a64f9",
+        },
+    ]
+
+    def run(self):
+        self.upload_dependency("C:\\%s" % self.filename)


### PR DESCRIPTION
https://github.com/a0rtega/pafish is a utility to run some VM detection checks. This can be used when creating VMs to see if they are reasonably well cloaked or hidden.