### PR TITLE
Linux support groundwork, add existing Linux vm to be managed by `vmcloak` + small bugfixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .gitignore
+/build/
+/dist/
 docs/_build
 *.pyc
+*.egg-info/

--- a/setup.py
+++ b/setup.py
@@ -41,10 +41,10 @@ setup(
         "vmcloak.data.win7": ["*.*"],
     },
     install_requires=[
-        "click==6.6",
-        "jinja2==2.8",
-        "pyyaml==3.12",
-        "sqlalchemy==1.0.8",
+        "click>=6.6",
+        "jinja2>=2.8",
+        "pyyaml>=3.12",
+        "sqlalchemy>=1.0.8",
     ],
     extras_require={
         ":sys_platform == 'win32'": [

--- a/vmcloak/__main__.py
+++ b/vmcloak/__main__.py
@@ -1,0 +1,4 @@
+from .main import main
+
+if __name__ == "__main__":
+	main()

--- a/vmcloak/agent.py
+++ b/vmcloak/agent.py
@@ -126,7 +126,7 @@ class Agent(object):
     def dns_server(self, ipaddr):
         """Set the IP address of the DNS server."""
         if self.system == "linux":
-            command = "echo '%s' > /etc/resolv.conf" % (ipaddr,)
+            command = "echo 'nameserver %s' > /etc/resolv.conf" % (ipaddr,)
         else:
             command = \
                 "netsh interface ip set dns " \

--- a/vmcloak/agent.py
+++ b/vmcloak/agent.py
@@ -106,7 +106,7 @@ class Agent(object):
         """Change the IP address of this machine."""
         if self.system == 'linux':
             command = (
-                "IFACE=`ip route ls | grep '^default' | cut -f 5 -d ' '`; export IFACE; ifconfig $IFACE %s netmask %s; route add default dev $IFACE"
+                "IFACE=`ip route ls | grep '^default' | cut -f 5 -d ' '`; export IFACE; ifconfig $IFACE %s netmask %s; route add default gw %s"
             ) % (ipaddr, netmask, gateway)
         else:
             command = (

--- a/vmcloak/agent.py
+++ b/vmcloak/agent.py
@@ -21,7 +21,7 @@ class Agent(object):
     @property
     def system(self):
         if not self._system:
-            self._system = self.get("/environ").json()["system"]
+            self._system = self.get("/system").json()["system"].lower()
         return self._system
 
     def get(self, method, *args, **kwargs):
@@ -106,7 +106,7 @@ class Agent(object):
         """Change the IP address of this machine."""
         if self.system == 'linux':
             command = (
-                "IFACE=`ip route ls | grep '^default' | cut -f 5 -d ' '` ifconfig $IFACE %s netmask %s; route add default dev $IFACE"
+                "IFACE=`ip route ls | grep '^default' | cut -f 5 -d ' '`; export IFACE; ifconfig $IFACE %s netmask %s; route add default dev $IFACE"
             ) % (ipaddr, netmask, gateway)
         else:
             command = (

--- a/vmcloak/agent.py
+++ b/vmcloak/agent.py
@@ -117,7 +117,7 @@ class Agent(object):
 
         try:
             requests.post("http://%s:%s/execute" % (self.ipaddr, self.port),
-                          data={"command": command}, timeout=5, shell=True)
+                          data={"command": command, shell: 'true'}, timeout=5)
         except requests.exceptions.ReadTimeout:
             pass
 

--- a/vmcloak/agent.py
+++ b/vmcloak/agent.py
@@ -117,7 +117,7 @@ class Agent(object):
 
         try:
             requests.post("http://%s:%s/execute" % (self.ipaddr, self.port),
-                          data={"command": command, shell: 'true'}, timeout=5)
+                          data={"command": command, "shell": 'true'}, timeout=5)
         except requests.exceptions.ReadTimeout:
             pass
 

--- a/vmcloak/main.py
+++ b/vmcloak/main.py
@@ -92,6 +92,41 @@ def clone(name, outname):
     session.commit()
 
 @main.command()
+@click.argument('name')
+@click.option("--path", help="Path to disk image")
+@click.option("--osversion", help="Operating system name.")
+@click.option("--servicepack", help="Service pack name.", default="")
+@click.option("--vm", default="virtualbox", help="Virtual Machinery.")
+@click.option("--ip", default="192.168.56.2", help="Guest IP address.")
+@click.option("--port", default=8000, type=int, help="Port to run the Agent on.")
+@click.option("--adapter", default="vboxnet0", help="Network adapter.")
+@click.option("--netmask", default="255.255.255.0", help="Guest IP address.")
+@click.option("--gateway", default="192.168.56.1", help="Guest IP address.")
+@click.option("--cpus", default=1, type=int, help="CPU count.")
+@click.option("--ramsize", default=1024, type=int, help="Memory size")
+@click.option("--vramsize", default=16, type=int, help="Video memory size")
+@click.option("--mode", default="normal", help="normal or multiattach")
+def add(name, path, osversion, servicepack, vm, ip, port, adapter,
+           netmask, gateway, cpus, ramsize, vramsize, mode):
+    if not os.path.exists(path):
+        log.error('Disk image not found: %s', path)
+        exit(1)
+
+    session = Session()
+
+    image = session.query(Image).filter_by(name=name).first()
+    if image:
+        log.error("Image already exists: %s", name)
+        exit(1)
+
+    session.add(Image(name=str(name), path=path, osversion=osversion,
+                      servicepack=str(servicepack), mode=mode,
+                      ipaddr=ip, port=port, adapter=adapter,
+                      netmask=netmask, gateway=gateway,
+                      cpus=cpus, ramsize=ramsize, vramsize=vramsize, vm=str(vm)))
+    session.commit()
+
+@main.command()
 @click.argument("name")
 @click.option("--winxp", is_flag=True, help="This is a Windows XP instance.")
 @click.option("--win7x86", is_flag=True, help="This is a Windows 7 32-bit instance.")

--- a/vmcloak/misc.py
+++ b/vmcloak/misc.py
@@ -12,6 +12,7 @@ import stat
 import struct
 import subprocess
 import sys
+import time
 
 from ConfigParser import ConfigParser
 
@@ -227,7 +228,7 @@ def wait_for_host(ipaddr, port):
             socket.create_connection((ipaddr, port), 1).close()
             break
         except socket.error:
-            pass
+            time.sleep(1)
 
 def drop_privileges(user):
     if not HAVE_PWD:

--- a/vmcloak/vm.py
+++ b/vmcloak/vm.py
@@ -82,8 +82,10 @@ class VirtualBox(Machinery):
     def vramsize(self, vramsize):
         return self._call("modifyvm", self.name, vram=vramsize)
 
-    def os_type(self, osversion):
+    def os_type(self, osversion, default="Other"):
         operating_systems = {
+            "linux": "Linux",
+            "linux64": "Linux_64",
             "winxp": "WindowsXP",
             "win7x86": "Windows7",
             "win7x64": "Windows7_64",
@@ -93,7 +95,7 @@ class VirtualBox(Machinery):
             "win10x64": "Windows10_64",
         }
         return self._call("modifyvm", self.name,
-                          ostype=operating_systems[osversion])
+                          ostype=operating_systems.get(osversion, default))
 
     def create_hd(self, hdd_path, fsize=256*1024):
         self._call("createhd", filename=hdd_path, size=fsize)


### PR DESCRIPTION
 * `vmcloak/misc.py`: don't spam console with 'Waiting for host' on connect error
 * `__main__.py`: you can do `python -mvmcloak`
 * `vmcloak/main.py`: created `vmcloak add` command to manually insert VMs into the repository
 * `vmcloak/vm.py`: added implicit support for more operating systems, Linux included
 * `vmcloak/agent.py`: added initial Linux support, so `vmcloak snapshot` works with Linux guest

The `vmcloak add` functionality is used by my cockatoo project to create the repository.db from scratch using .opt files next to the .vdi file