### PR TITLE
Add Windows 7 key to the specialize section

### DIFF
--- a/vmcloak/data/win7/autounattend.xml
+++ b/vmcloak/data/win7/autounattend.xml
@@ -65,6 +65,7 @@
         </component>
         <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="@ARCH@" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <ComputerName>@COMPUTERNAME@</ComputerName>
+            <ProductKey>@PRODUCTKEY@</ProductKey>
             <ShowWindowsLive>false</ShowWindowsLive>
         </component>
         <component name="Security-Malware-Windows-Defender" processorArchitecture="@ARCH@" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">


### PR DESCRIPTION
This should help somewhat with MAK keys, but not fully.

I am not so sure if it works with VLK keys though, but it should hopefully at least partially fix #102.

According to http://www.msfn.org/board/topic/146931-kms-mak-product-keys-in-autounattendxml/ the default (VLK) key by MS should be supplied in the WinPE phase and the MAK key in the specialize section.
This seems to work, but still needs some stuff in vmcloak: The real fix is to have all default keys in vmcloak, select the proper one according to the --product setting and add another "key type" switch or similar that indicates if a MAK or VLK key is being used. The current setup seems to only work with VLK keys.

Unfortunately I don't know of a good way to distinguish the keys by looking at them, Microsoft at least offers a tool ("VAMT 2.0") at https://blogs.technet.microsoft.com/askcore/2010/09/13/how-to-verify-or-check-your-kmsmak-product-key/ where one can check the actual key type.

So far I managed to at least install a Win7 Enterprise by hard coding the default VLK key in the XML and adding this patch on top to use the MAK key automatically. I have yet to verify if it actually worked and will activate, at least I did not get any "invalid key in unattended installation file" errors like I got before (with only this patch applied).