### PR TITLE
add option to change paravirtprovider

### DIFF
--- a/vmcloak/main.py
+++ b/vmcloak/main.py
@@ -116,12 +116,14 @@ def clone(name, outname):
 @click.option("--tempdir", default=iso_dst_path, help="Temporary directory to build the ISO file.")
 @click.option("--resolution", default="1024x768", help="Screen resolution.")
 @click.option("--vm-visible", is_flag=True, help="Start the Virtual Machine in GUI mode.")
+@click.option("--paravirtprovider", default="default",
+              help="Select paravirtprovider for Virtualbox none|default|legacy|minimal|hyperv|kvm")
 @click.option("-d", "--debug", is_flag=True, help="Install Virtual Machine in debug mode.")
 @click.option("-v", "--verbose", is_flag=True, help="Verbose logging.")
 def init(name, winxp, win7x86, win7x64, win81x86, win81x64, win10x86,
          win10x64, product, vm, iso_mount, serial_key, ip, port, adapter,
          netmask, gateway, dns, cpus, ramsize, vramsize, tempdir, resolution,
-         vm_visible, debug, verbose):
+         vm_visible, paravirtprovider, debug, verbose):
     if verbose:
         log.setLevel(logging.INFO)
     if debug:
@@ -226,6 +228,7 @@ def init(name, winxp, win7x86, win7x64, win81x86, win81x64, win10x86,
     if vm == "virtualbox":
         m.create_vm()
         m.os_type(osversion)
+        m.paravirtprovider(paravirtprovider)
         m.cpus(cpus)
         m.mouse("usbtablet")
         m.ramsize(ramsize)

--- a/vmcloak/main.py
+++ b/vmcloak/main.py
@@ -57,6 +57,7 @@ def initvm(image, name=None, multi=False, ramsize=None, vramsize=None, cpus=None
         # Ensure the slot is at least allocated for by an empty drive.
         m.detach_iso()
         m.hostonly(nictype=h.nictype, adapter=image.adapter)
+        m.paravirtprovider(image.paravirtualization)
 
     return m, h
 

--- a/vmcloak/main.py
+++ b/vmcloak/main.py
@@ -57,7 +57,7 @@ def initvm(image, name=None, multi=False, ramsize=None, vramsize=None, cpus=None
         # Ensure the slot is at least allocated for by an empty drive.
         m.detach_iso()
         m.hostonly(nictype=h.nictype, adapter=image.adapter)
-        m.paravirtprovider(image.paravirtualization)
+        m.paravirtprovider(image.paravirtprovider)
 
     return m, h
 
@@ -257,7 +257,8 @@ def init(name, winxp, win7x86, win7x64, win81x86, win81x64, win10x86,
                       servicepack="%s" % h.service_pack, mode="normal",
                       ipaddr=ip, port=port, adapter=adapter,
                       netmask=netmask, gateway=gateway,
-                      cpus=cpus, ramsize=ramsize, vramsize=vramsize, vm="%s" % vm))
+                      cpus=cpus, ramsize=ramsize, vramsize=vramsize, vm="%s" % vm,
+                      paravirtprovider=paravirtprovider))
     session.commit()
 
 @main.command()

--- a/vmcloak/repository.py
+++ b/vmcloak/repository.py
@@ -39,6 +39,7 @@ class Image(Base):
     cpus = Column(Integer)
     ramsize = Column(Integer)
     vramsize = Column(Integer)
+    paravirtualization = Column(String(32))
 
 class Snapshot(Base):
     """Represents each snapshot that has been created."""

--- a/vmcloak/repository.py
+++ b/vmcloak/repository.py
@@ -39,7 +39,7 @@ class Image(Base):
     cpus = Column(Integer)
     ramsize = Column(Integer)
     vramsize = Column(Integer)
-    paravirtualization = Column(String(32))
+    paravirtprovider = Column(String(32))
 
 class Snapshot(Base):
     """Represents each snapshot that has been created."""

--- a/vmcloak/vm.py
+++ b/vmcloak/vm.py
@@ -225,6 +225,9 @@ class VirtualBox(Machinery):
         return self._call("modifyvm", self.name, vrde="on", vrdeport=port,
                           vrdeproperty="VNCPassword=%s" % password)
 
+    def paravirtprovider(self, provider):
+        return self._call("modifyvm", self.name, paravirtprovider=provider)
+
     def export(self, filepath):
         return self._call(
             "export", self.name, "--output", filepath, "--vsys", "0",


### PR DESCRIPTION
This PR provides ability for vmcloak to change paravirtprovider in virtualbox 5.1 to any of following none|default|legacy|minimal|hyperv|kvm. 