### PR TITLE
Include a default version of Firefox, fixes #134

### DIFF
--- a/vmcloak/dependencies/firefox.py
+++ b/vmcloak/dependencies/firefox.py
@@ -9,6 +9,7 @@ from vmcloak.abstract import Dependency
 
 class Firefox(Dependency):
     name = "firefox"
+    default = "41.0.2"
     exes = [{
         "version": "41.0.2",
         "url": "https://cuckoo.sh/vmcloak/Firefox_Setup_41.0.2.exe",


### PR DESCRIPTION
Including a default version of Firefox in a similar fashion to how chrome.py works. Quickly tested on win81x64. Fixes #134