### PR TITLE
edge dependency

### DIFF
--- a/vmcloak/dependencies/edge.py
+++ b/vmcloak/dependencies/edge.py
@@ -1,0 +1,19 @@
+from vmcloak.abstract import Dependency
+
+class Edge(Dependency):
+    name = "edge"
+    
+    def run(self):
+        self.a.execute(
+            "reg add \"HKEY_LOCAL_MACHINE\\Software\\"
+            "Microsoft\\Windows\\CurrentVersion\\"
+            "Policies\\System\" "
+            "/v FilterAdministratorToken /t REG_DWORD /d 1 /f"
+        )
+        self.a.execute(
+            "reg add \"HKEY_LOCAL_MACHINE\\Software\\"
+            "Microsoft\\Windows\\CurrentVersion\\"
+            "Policies\\System\\UIPI\" "
+            "/v \"\" /t REG_SZ /d \"1\" /f"
+        )
+


### PR DESCRIPTION
To run edge on windows 10 these regkeys should be added. This is not possible to do in the analyzer package itself because a restart is required. 