### PR TITLE
List VMs, fix list deps, and update sqlalchemy version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         "jinja2==2.9.6",
         "pefile2==1.2.11",
         "pyyaml==3.12",
-        "sqlalchemy==1.0.8",
+        "sqlalchemy==1.3.3",
         "alembic>=1.0.7, <1.1",
     ],
     extras_require={

--- a/vmcloak/main.py
+++ b/vmcloak/main.py
@@ -666,7 +666,7 @@ def migrate(revision):
     log.info("Database migration successful!")
 
 def list_dependencies():
-    print "Name", "version", "target", "sha1"
+    print "Name", "version", "target", "sha1", "arch",
     print
     for name, d in sorted(vmcloak.dependencies.names.items()):
         if d.exes:
@@ -679,8 +679,20 @@ def list_dependencies():
             v = exe.get("version", "None")
             print "  *" if d.default and d.default == v else "   ",
             print exe.get("version", "None") + " "*(versionlen - len(v)),
-            print exe.get("target"), exe["sha1"]
+            print exe.get("target"), exe.get("sha1", "None"),
+            print exe.get("arch", "")
         print
+
+def list_vms():
+    session = Session()
+    vms = []
+    try:
+        vms = session.query(Snapshot).all()
+    finally:
+        session.close()
+
+    for vm in vms:
+        print vm.vmname, vm.ipaddr
 
 @main.group("list")
 def _list():
@@ -693,3 +705,7 @@ def _list_dependencies():
 @_list.command("deps")
 def _list_deps():
     list_dependencies()
+
+@_list.command("vms")
+def _list_vms():
+    list_vms()


### PR DESCRIPTION
- VM listing tool which lists all snaphot names and IPs.

Can be used for commands such as:
`while read -r vm ip; do cuckoo machine --add $vm $ip; done < <(vmcloak list vms)`

- Fix keyerror when listing deps and adding the arch in this list
- Bump sqlalchemy to 1.3.3. This ensures that this will match the version with Cuckoo after its new release, thus allowing vmcloak and cuckoo to be installed in the same virtualenv.