### PR TITLE
ACPI Shutdown + more recent Python as default

### DIFF
--- a/vmcloak/dependencies/acpishutdown.py
+++ b/vmcloak/dependencies/acpishutdown.py
@@ -1,0 +1,28 @@
+# Copyright (C) 2019 Jurriaan Bremer.
+# This file is part of VMCloak - http://www.vmcloak.org/.
+# See the file 'docs/LICENSE.txt' for copying permission.
+
+from vmcloak.abstract import Dependency
+
+class ACPIShutdown(Dependency):
+    """Tells Windows that to do if an ACPI shutdown signal (power button) is
+    sent. These settings tell Windows to shut down."""
+    name = "acpishutdown"
+
+    def run(self):
+        # Tell Windows to shut down if the power button is clicked when it
+        # is running on the battery
+        self.a.execute(
+            "c:\\Windows\\System32\\powercfg.exe "
+            "-setdcvalueindex SCHEME_CURRENT "
+            "4f971e89-eebd-4455-a8de-9e59040e7347 "
+            "7648efa3-dd9c-4e3e-b566-50f929386280 3"
+        )
+        # Tell Windows to shut down if the power button is clicked when it is
+        # not running from the battery
+        self.a.execute(
+            "c:\\Windows\\System32\\powercfg.exe "
+            "-setacvalueindex SCHEME_CURRENT "
+            "4f971e89-eebd-4455-a8de-9e59040e7347 "
+            "7648efa3-dd9c-4e3e-b566-50f929386280 3"
+        )

--- a/vmcloak/dependencies/python.py
+++ b/vmcloak/dependencies/python.py
@@ -6,7 +6,7 @@ from vmcloak.abstract import Dependency
 
 class Python(Dependency):
     name = "python"
-    default = "2.7.6"
+    default = "2.7.13"
     exes = [{
         "version": "2.7.6",
         "urls": [

--- a/vmcloak/main.py
+++ b/vmcloak/main.py
@@ -138,7 +138,7 @@ def clone(name, outname):
 @click.option("--vm-visible", is_flag=True, help="Start the Virtual Machine in GUI mode.")
 @click.option("--vrde", is_flag=True, help="Enable the VirtualBox Remote Display Protocol.")
 @click.option("--vrde-port", default=3389, help="Specify the VRDE port.")
-@click.option("--python-version", default="2.7.6", help="Which Python version do we install on the guest?")
+@click.option("--python-version", default="2.7.13", help="Which Python version do we install on the guest?")
 @click.option("--paravirtprovider", default="default",
               help="Select paravirtprovider for Virtualbox none|default|legacy|minimal|hyperv|kvm")
 @click.option("-d", "--debug", is_flag=True, help="Install Virtual Machine in debug mode.")


### PR DESCRIPTION
* A more recent Python version, which includes pip and stops TLS errors.
* Support to enable a ACPI signal shutdown in case a normal OS shutdown is desired.