### PR TITLE
vmcloak init command uses obsolete argumets for genisoimage, mkisofs and qemu-system-x86_64 internaly

### DIFF
--- a/vmcloak/abstract.py
+++ b/vmcloak/abstract.py
@@ -204,7 +204,7 @@ class WindowsAutounattended(OperatingSystem):
     dummy_serial_key = None
     genisoargs = [
         "-no-emul-boot", "-iso-level", "2", "-udf", "-J", "-l", "-D", "-N",
-        "-joliet-long", "-relaxed-filenames", "-allow-limited-size",
+        "-joliet-long", "-relaxed-filenames",
     ]
 
     def _autounattend_xml(self, product, ipaddress, gateway):

--- a/vmcloak/platforms/qemu.py
+++ b/vmcloak/platforms/qemu.py
@@ -58,7 +58,8 @@ def _make_pre_v41_args(attr):
         "-device", "ide-cd,bus=ahci.1,unit=0,drive=cdrom,bootindex=1",
         "-device", "usb-ehci,id=ehci",
         "-device", "usb-tablet,bus=ehci.0",
-        "-soundhw", "hda",
+        "-device", "intel-hda",
+        "-device", "hda-duplex",
         "--enable-kvm"
     ]
 
@@ -82,7 +83,8 @@ def _make_post_v41_args(attr):
         "-device", "ide-cd,bus=ahci.1,unit=0,drive=cdrom,bootindex=1",
         "-device", "usb-ehci,id=ehci",
         "-device", "usb-tablet,bus=ehci.0",
-        "-soundhw", "hda",
+        "-device", "intel-hda",
+        "-device", "hda-duplex",
         "-enable-kvm"
     ]
 


### PR DESCRIPTION
I tried creating an a base image using vmcloak init but i got two errors.

The errors and how to fix them is described in #204 and #206.
