### PR TITLE
Update browser installer URLs

### DIFF
--- a/vmcloak/dependencies/chrome.py
+++ b/vmcloak/dependencies/chrome.py
@@ -9,12 +9,11 @@ from vmcloak.abstract import Dependency
 
 class Chrome(Dependency):
     name = "chrome"
-    default = "46.0.2490.80"
+    default = "109.0.5414.165"
     tags = ["browser_chrome"]
     exes = [{
-        "version": "46.0.2490.80",
-        "url": "https://cuckoo.sh/vmcloak/googlechromestandaloneenterprise.msi",
-        "sha1": "a0ade494dda8911eeb68c9294c2dd0e3229d8f02",
+        "version": "109.0.5414.165",
+        "url": "https://archive.org/download/chrome-109-Win7-8/Chrome%20109%20%28Enterprise%29%20x64.msi",
     }, {
         "version": "latest",
         "arch": "x86",

--- a/vmcloak/dependencies/firefox.py
+++ b/vmcloak/dependencies/firefox.py
@@ -7,26 +7,19 @@ from vmcloak.abstract import Dependency
 
 class Firefox(Dependency):
     name = "firefox"
-    default = "41.0.2"
+    default = "128.3.0esr"
     tags = ["browser_firefox"]
     exes = [{
-        "version": "41.0.2",
-        "url": "https://cuckoo.sh/vmcloak/Firefox_Setup_41.0.2.exe",
+        "version": "128.3.0esr",
+        "url": "https://download.mozilla.org/?product=firefox-esr-msi-latest-ssl&os=win64&lang=en-US",
         "sha1": "c5118ca76f0cf6ecda5d2b9292bf191525c9627a",
-    }, {
-        "version": "60.0.2",
-        "url": "https://cuckoo.sh/vmcloak/firefox_60_0_2.exe",
-        "sha1": "565c5ddca3e4acbc30a550f312d3a1a7fd8d8bce",
-    }, {
-        "version": "63.0.3",
-        "url": "https://cuckoo.sh/vmcloak/firefox_63_0_3.exe",
-        "sha1": "c5f03fc93aebd2db9da14ba6eb1f01e98e18d95b",
     }]
 
     def run(self):
-        self.upload_dependency("C:\\Firefox_Setup_41.0.2.exe")
-        self.a.execute("C:\\Firefox_Setup_41.0.2.exe -ms")
-        self.a.remove("C:\\Firefox_Setup_41.0.2.exe")
+        self.upload_dependency("C:\\%s" % self.filename)
+
+        self.a.execute("msiexec /i C:\\%s /passive /norestart" % self.filename)
+        self.a.remove("C:\\%s" % self.filename)
 
 class Firefox41(Firefox, Dependency):
     """Backwards compatibility"""

--- a/vmcloak/dependencies/firefox.py
+++ b/vmcloak/dependencies/firefox.py
@@ -7,12 +7,14 @@ from vmcloak.abstract import Dependency
 
 class Firefox(Dependency):
     name = "firefox"
-    default = "128.3.0esr"
+    default = "115.16.0esr"
     tags = ["browser_firefox"]
     exes = [{
+        "version": "115.16.0esr",
+        "url": "https://ftp.mozilla.org/pub/firefox/releases/115.16.0esr/win64/en-US/Firefox%20Setup%20115.16.0esr.msi",
+    },{
         "version": "128.3.0esr",
-        "url": "https://download.mozilla.org/?product=firefox-esr-msi-latest-ssl&os=win64&lang=en-US",
-        "sha1": "c5118ca76f0cf6ecda5d2b9292bf191525c9627a",
+        "url": "https://ftp.mozilla.org/pub/firefox/releases/128.3.0esr/win64/en-US/Firefox%20Setup%20128.3.0esr.msi",
     }]
 
     def run(self):


### PR DESCRIPTION
cuckoo.sh browser installer files no longer seem to be available, updated Windows 7 compatible Chrome and Firefox to publicly accessible URLs for everyone's benefit